### PR TITLE
Add custom cron schedule through ENV

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,12 @@ if [ -f /config/.fetchmailrc ]; then
 	echo "Installed .fetchmailrc"
 fi
 
+# check for custom cron schedule
+if [[ -n "$CRON_SCHEDULE" ]]; then
+  sed -i 's|\* \* \* \* \*|'"$CRON_SCHEDULE"'|g' /etc/cron.d/save-attachments
+  echo "Installed custom cron: $CRON_SCHEDULE"
+fi
+
 # update CA certificates if necessary from /config/*.crt
 if stat --printf='' /config/*.crt 2>/dev/null
 then


### PR DESCRIPTION
Hi Chris,

Really nice image! Unfortunately, some mail providers don't like abuse (polling every minute). Therefore, you can specify the cron schedule through an ENV variable, like `-e CRON_SCHEDULE='*/15 * * * *'`. If you don't specify the variable, the default of every minute is kept. Hopefully, it's useful for other people as well.